### PR TITLE
Use input stream to set the remote file name (android)

### DIFF
--- a/src/android/CDVFtp.java
+++ b/src/android/CDVFtp.java
@@ -28,6 +28,8 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
@@ -260,11 +262,14 @@ public class CDVFtp extends CordovaPlugin {
 		{
 			try {
 				String remoteFilePath = remoteFile.substring(0, remoteFile.lastIndexOf('/') + 1);
-				//String remoteFileName = remoteFile.substring(remoteFile.lastIndexOf('/') + 1);
+				String remoteFileName = remoteFile.substring(remoteFile.lastIndexOf('/') + 1);
+				String localFilePath = localFile.substring(0, localFile.lastIndexOf('/') + 1);
+				String localFileName = localFile.substring(localFile.lastIndexOf('/') + 1);
 				this.client.changeDirectory(remoteFilePath);
 				File file = new File(localFile);
-				long size = file.length();
-				client.upload(file, new CDVFtpTransferListener(size, callbackContext));
+				InputStream in =  new FileInputStream(file);
+				long size = file.length();				
+				client.upload(remoteFileName, in, 0, 0, new CDVFtpTransferListener(size, callbackContext));
 				// refer to CDVFtpTransferListener for transfer percent and completed
 			} catch (Exception e) {
 				callbackContext.error(e.toString());


### PR DESCRIPTION
android ftp upload with remote file name same as local file name, which is not the same behavior as iOS plugin.

people get confused when they give a remote file path parameter but the remote file uploaded with a different name.

Since ftp4j don't have a function to set the uploaded file name, I tried to change local file name as a workaround.
